### PR TITLE
Fix for #18

### DIFF
--- a/app/tray.js
+++ b/app/tray.js
@@ -39,7 +39,8 @@ function getIcon()
 }
 
 function setTitle(title) {
-    tray.setTitle(title)
+    const WHITE = '\033[37;1m'
+    tray.setTitle(WHITE + title)
 }
 
 function setHighlightMode(mode) {


### PR DESCRIPTION
<img width="411" alt="Screen Shot 2022-11-14 at 11 00 13" src="https://user-images.githubusercontent.com/1967999/201631763-a6e4e60b-747d-4745-9ef0-713e3791af5b.png">
<img width="409" alt="Screen Shot 2022-11-14 at 11 00 21" src="https://user-images.githubusercontent.com/1967999/201631766-c71db441-271c-44dc-bafb-850472097bc0.png">

This fixes issue #18. Admittedly, the black icon in the light theme looks a bit weird, but it looks like it's intentional, so I'll leave this as is :)