### PR TITLE
Update the build script to to produce universal binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ builds
 macos
 electron-builder.yml
 package-lock.json
+dist
 
 .DS_*
 .Trashes

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "app/index.js",
   "scripts": {
     "start": "DEV=true electron .",
-    "build": "electron-builder build --mac --publish never",
-    "publish": "electron-builder build --mac --publish always",
+    "build": "electron-builder build --mac --universal --publish never",
+    "publish": "electron-builder build --mac --universal --publish always",
     "sign-dev-electron-app": "codesign --deep --force --verbose --sign - node_modules/electron/dist/Electron.app",
     "postinstall": "npm run sign-dev-electron-app"
   },


### PR DESCRIPTION
The universal builds containing arm64 and x64 binary, natively supporting new Apple Silicon and older Apple Intel

![image](https://user-images.githubusercontent.com/18055365/203087407-dafdbaac-d838-4085-b370-2717589bb446.png)

Closes #21 