### PR TITLE
Fix Hovrly not appearing over fullscreen apps

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -24,6 +24,10 @@ app.console = new console.Console(process.stdout, process.stderr)
 app.whenReady().then(() => {
     console.log('index init')
 
+    if (process.platform === 'darwin') {
+        app.dock.hide()
+    }
+
     window.init()
     menu.init()
     tray.init()
@@ -34,10 +38,6 @@ app.whenReady().then(() => {
     db.init()
 
     ipc.on('ready', () => {
-        if(process.platform == 'darwin') {
-            app.dock.hide()
-        }
-
         setTimeout(updater.auto, config.DELAYED_INIT)
 
         console.timeEnd('inited')

--- a/app/window.js
+++ b/app/window.js
@@ -28,6 +28,7 @@ function init() {
         movable: false,
         icon: config.DOCK_ICON,
         skipTaskbar: true,
+        alwaysOnTop: true,
         webPreferences: {
             preload: `${__dirname}/preload.js`,
             nodeIntegration: true,
@@ -39,7 +40,8 @@ function init() {
     positioner = new Positioner(win)
 
     win.webContents.loadURL(`file://${__dirname}/templates/index.html`)
-    win.setVisibleOnAllWorkspaces(true)
+    win.setAlwaysOnTop(true, 'floating', 1)
+    win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
     if(isDev && config.DEV_TOOLS) win.webContents.openDevTools();
 
     win.once('ready-to-show', () => {
@@ -69,7 +71,10 @@ function getWin() {
 function show() {
     let position = positioner.calculate('trayLeft', tray.getBounds())
     win.setPosition(position.x - 7, position.y + 10, false)
-    win.show()
+    win.setAlwaysOnTop(true, 'floating', 1)
+    win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
+    win.showInactive()
+    win.focus()
 }
 
 function hide() {


### PR DESCRIPTION
Summary

  - Moved app.dock.hide() before window initialization so the process activation policy is set before the BrowserWindow is created
  - Added alwaysOnTop with floating window level and visibleOnFullScreen collection behavior to allow the window to render above fullscreen apps
  - Changed show() to use showInactive() + focus() instead of show() to prevent macOS from switching spaces when the window appears
  - Re-applies window level and workspace visibility on each show to prevent hide() from resetting them

  Test plan

  - Open any app in fullscreen mode
  - Click the Hovrly tray icon — the popup should appear over the fullscreen app without switching spaces
  - Verify Hovrly still works normally on regular (non-fullscreen) desktops
  - Verify the popup dismisses on blur (clicking elsewhere)